### PR TITLE
Update 11.12

### DIFF
--- a/Assets/Animation/bloon move.controller
+++ b/Assets/Animation/bloon move.controller
@@ -61,7 +61,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Enemy_attack
-  m_Speed: 1
+  m_Speed: 0.75
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -9144302361302418813}
@@ -207,13 +207,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: canWalk
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Prefabs/blooncat.prefab
+++ b/Assets/Prefabs/blooncat.prefab
@@ -1,0 +1,409 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5130375401953032092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5130375401953032093}
+  m_Layer: 8
+  m_Name: raycast
+  m_TagString: Untagged
+  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5130375401953032093
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375401953032092}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.24, y: -1.48, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5226218537142015530}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5130375402500137111
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5130375402500137108}
+  - component: {fileID: 5130375402500137109}
+  m_Layer: 9
+  m_Name: triggerArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 3936346786652291628, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5130375402500137108
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375402500137111}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.5, y: -1.13, z: 0}
+  m_LocalScale: {x: 1.5, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5226218537142015530}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &5130375402500137109
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375402500137111}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 1.0406666, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 3.0813332, y: 1}
+  m_EdgeRadius: 0
+--- !u!1 &5130375402860037200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5130375402860037201}
+  m_Layer: 9
+  m_Name: enemy_sprites
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5130375402860037201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375402860037200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5226218537142015530}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5130375403038088347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5130375403038088344}
+  m_Layer: 9
+  m_Name: enemy_collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5130375403038088344
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375403038088347}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5226218537142015530}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!1 &5130375403528309732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5130375403528309733}
+  - component: {fileID: 5130375403528309730}
+  m_Layer: 9
+  m_Name: hitBox
+  m_TagString: Untagged
+  m_Icon: {fileID: -1412012063857583412, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5130375403528309733
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375403528309732}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.55, y: -0.46, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5226218537142015530}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &5130375403528309730
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5130375403528309732}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.22389793, y: 0.18420887}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.4215355, y: 0.31096458}
+  m_EdgeRadius: 0
+--- !u!1 &5226218537142015532
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5226218537142015530}
+  - component: {fileID: 5226218537142015531}
+  - component: {fileID: 5226218537142015529}
+  - component: {fileID: 5226218537142015527}
+  - component: {fileID: 3494667606849171116}
+  - component: {fileID: 5130375401906703147}
+  - component: {fileID: 5259067016775476252}
+  m_Layer: 9
+  m_Name: blooncat
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5226218537142015530
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -44.93, y: -17.6, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5130375403038088344}
+  - {fileID: 5130375402860037201}
+  - {fileID: 5130375403528309733}
+  - {fileID: 5130375402500137108}
+  - {fileID: 5130375401953032093}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5226218537142015531
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -7781385479087960072, guid: 9d6ffdca57dfeba48aa001f2f80dbe4d,
+    type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 3.4461539, y: 3.323077}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &5226218537142015529
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.07, y: -0.7}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.56081307, y: 0.48291248}
+    oldSize: {x: 1.02, y: 1.7}
+    newSize: {x: 3.4461539, y: 3.323077}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.5}
+  m_EdgeRadius: 0
+--- !u!50 &5226218537142015527
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 6
+--- !u!95 &3494667606849171116
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: a54ae6ade155c86429c34ffb16bb3baa, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &5130375401906703147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 929180e66b24a03409d059a292d34c64, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rayCast: {fileID: 5130375401953032093}
+  raycastMask:
+    serializedVersion: 2
+    m_Bits: 1024
+  rayCastLength: 4
+  attackDistance: 2
+  moveSpeed: 2
+  timer: 2
+  leftLimit: {fileID: 0}
+  rightLimit: {fileID: 0}
+  health: 2
+--- !u!66 &5259067016775476252
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5226218537142015532}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 0
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths: []
+  m_CompositePaths:
+    m_Paths: []
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/Prefabs/blooncat.prefab.meta
+++ b/Assets/Prefabs/blooncat.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c8d9285cf925a684b80689342d0ec44e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Level1 Scene.unity
+++ b/Assets/Scenes/Level1 Scene.unity
@@ -121,166 +121,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &57287804
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1131955118306753282, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Constraints
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753282, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_GravityScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753289, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Name
-      value: blooncat (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 1.2314262
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 1.0221863
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Offset.x
-      value: -0.04367256
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Offset.y
-      value: -0.44265175
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_UsedByComposite
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.x
-      value: 0.56081307
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.y
-      value: 0.48291248
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.x
-      value: 1.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 1.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753294, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_FlipX
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753294, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: -7781385479087960072, guid: 9d6ffdca57dfeba48aa001f2f80dbe4d,
-        type: 3}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 24
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 32.086906
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -10.61084
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1459926277965439960, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.46
-      objectReference: {fileID: 0}
-    - target: {fileID: 1459926277965439960, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.43
-      objectReference: {fileID: 0}
-    - target: {fileID: 3493642560162253768, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 7.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 3493642560162253768, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.57
-      objectReference: {fileID: 0}
-    - target: {fileID: 8596611459759047561, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: a54ae6ade155c86429c34ffb16bb3baa, type: 2}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4bed39a69e2d7d147b57c2c9b2106688, type: 3}
 --- !u!1 &69999715
 GameObject:
   m_ObjectHideFlags: 0
@@ -496,12 +336,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 96729489}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -49.92, y: -15.75, z: -10}
+  m_LocalPosition: {x: -49.479996, y: -15.75, z: -10.00001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 456425960}
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &96729492
 MonoBehaviour:
@@ -528,63 +368,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1397524362}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &150318761
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 150318762}
-  - component: {fileID: 150318763}
-  m_Layer: 9
-  m_Name: triggerArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 3936346786652291628, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &150318762
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150318761}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.48, y: -1.13, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1584116725}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &150318763
+--- !u!61 &115188309 stripped
 BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 5226218537142015529, guid: c8d9285cf925a684b80689342d0ec44e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2105168833}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150318761}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 1.0406666, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 3.0813332, y: 1}
-  m_EdgeRadius: 0
 --- !u!1 &157530839
 GameObject:
   m_ObjectHideFlags: 0
@@ -636,7 +425,7 @@ PrefabInstance:
     - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
         type: 3}
@@ -710,120 +499,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4bed39a69e2d7d147b57c2c9b2106688, type: 3}
---- !u!1 &168743849
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 168743850}
-  - component: {fileID: 168743851}
-  m_Layer: 9
-  m_Name: triggerArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 3936346786652291628, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &168743850
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 168743849}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.48, y: -1.13, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 353002286}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &168743851
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 168743849}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 1.0406666, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 3.0813332, y: 1}
-  m_EdgeRadius: 0
---- !u!1 &230731930
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 230731931}
-  - component: {fileID: 230731932}
-  m_Layer: 9
-  m_Name: hitBox
-  m_TagString: Untagged
-  m_Icon: {fileID: -1412012063857583412, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &230731931
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 230731930}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.55, y: -0.46, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1836675160}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &230731932
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 230731930}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.22389793, y: 0.18420887}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.4215355, y: 0.31096458}
-  m_EdgeRadius: 0
 --- !u!1 &242797170
 GameObject:
   m_ObjectHideFlags: 0
@@ -996,9 +671,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Moving towards the wall and press SPACE to wall jump
-
-'
+  m_text: "Move towards the wall \nand press SPACE to \nwall jump\n"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1025,14 +698,14 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 5
-  m_fontSizeBase: 5
+  m_fontSize: 7
+  m_fontSizeBase: 7
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 1
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -1061,7 +734,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 1
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 6.4700375, w: 3.8002062}
+  m_margin: {x: 0, y: 0, z: -0.02782631, w: 0.0347023}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -1128,47 +801,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -23.51, y: -16.33}
-  m_SizeDelta: {x: 20, y: 5}
+  m_AnchoredPosition: {x: -32.57, y: -15.11}
+  m_SizeDelta: {x: 14.655819, y: 5}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &353002280 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1131955118306753289, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-    type: 3}
-  m_PrefabInstance: {fileID: 2006729960}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &353002281
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 353002280}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 929180e66b24a03409d059a292d34c64, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rayCast: {fileID: 1836900954}
-  raycastMask:
-    serializedVersion: 2
-    m_Bits: 1024
-  rayCastLength: 4
-  attackDistance: 2
-  moveSpeed: 2
-  timer: 2
-  leftLimit: {fileID: 1971615676}
-  rightLimit: {fileID: 713764171}
---- !u!4 &353002286 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-    type: 3}
-  m_PrefabInstance: {fileID: 2006729960}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &388814519 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6474417508408526729, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
@@ -1458,63 +1097,6 @@ Transform:
   m_Father: {fileID: 1919021714}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &549454587
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 549454588}
-  - component: {fileID: 549454589}
-  m_Layer: 9
-  m_Name: hitBox
-  m_TagString: Untagged
-  m_Icon: {fileID: -1412012063857583412, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &549454588
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 549454587}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.55, y: -0.46, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 353002286}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &549454589
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 549454587}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.22389793, y: 0.18420887}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.4215355, y: 0.31096458}
-  m_EdgeRadius: 0
 --- !u!1 &608539550 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3348315777731550572, guid: e1458b5b14dfee741b9772127682db2f,
@@ -1547,36 +1129,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.3246078, y: 1.429409}
   m_EdgeRadius: 0
---- !u!1 &671672293
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 671672294}
-  m_Layer: 9
-  m_Name: enemy_collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &671672294
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 671672293}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1836675160}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &713764170
 GameObject:
   m_ObjectHideFlags: 0
@@ -1732,7 +1284,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &905904405
 GameObject:
@@ -1748,7 +1300,7 @@ GameObject:
   - component: {fileID: 905904409}
   - component: {fileID: 905904410}
   - component: {fileID: 905904411}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Enemy g
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1839,7 +1391,7 @@ Transform:
   - {fileID: 1288691068}
   - {fileID: 273748342}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &905904409
 MonoBehaviour:
@@ -1937,7 +1489,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 2}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &912652646
 SpriteRenderer:
@@ -1989,6 +1541,12 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &938928827 stripped
+BoxCollider2D:
+  m_CorrespondingSourceObject: {fileID: 5226218537142015529, guid: c8d9285cf925a684b80689342d0ec44e,
+    type: 3}
+  m_PrefabInstance: {fileID: 2146749481}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1008195914
 GameObject:
   m_ObjectHideFlags: 0
@@ -1999,7 +1557,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1008195915}
   m_Layer: 0
-  m_Name: bloon mov limt (2)
+  m_Name: bloon mov limt (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2019,7 +1577,7 @@ Transform:
   - {fileID: 1971615676}
   - {fileID: 713764171}
   m_Father: {fileID: 0}
-  m_RootOrder: 27
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1086449334
 GameObject:
@@ -2050,7 +1608,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1086449336
 MonoBehaviour:
@@ -2256,36 +1814,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1152213230}
   m_CullTransparentMesh: 0
---- !u!1 &1161467295
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1161467296}
-  m_Layer: 9
-  m_Name: enemy_collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1161467296
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1161467295}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1584116725}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1001 &1166710292
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2461,196 +1989,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1166710292}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1177476551
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1177476552}
-  m_Layer: 9
-  m_Name: enemy_sprites
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1177476552
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1177476551}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1584116725}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1187436123
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1131955118306753282, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Constraints
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753282, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_GravityScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753289, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Name
-      value: blooncat
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 1.2314262
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 1.0221863
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Offset.x
-      value: -0.04367256
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Offset.y
-      value: -0.44265175
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_UsedByComposite
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.x
-      value: 0.56081307
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.y
-      value: 0.48291248
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.x
-      value: 1.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 1.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753294, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_FlipX
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753294, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: -7781385479087960072, guid: 9d6ffdca57dfeba48aa001f2f80dbe4d,
-        type: 3}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 21
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -44.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -17.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1459926277965439960, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.46
-      objectReference: {fileID: 0}
-    - target: {fileID: 1459926277965439960, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.43
-      objectReference: {fileID: 0}
-    - target: {fileID: 3493642560162253768, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 7.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 3493642560162253768, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.57
-      objectReference: {fileID: 0}
-    - target: {fileID: 8596611459759047561, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: a54ae6ade155c86429c34ffb16bb3baa, type: 2}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4bed39a69e2d7d147b57c2c9b2106688, type: 3}
 --- !u!1 &1190659725
 GameObject:
   m_ObjectHideFlags: 0
@@ -2743,7 +2081,7 @@ RectTransform:
   m_Children:
   - {fileID: 1985144634}
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2792,95 +2130,8 @@ Transform:
   m_Children:
   - {fileID: 1517096336}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1201065772
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1201065773}
-  m_Layer: 8
-  m_Name: raycast
-  m_TagString: Untagged
-  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1201065773
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1201065772}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.24, y: -1.48, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1584116725}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1209555945
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1209555946}
-  - component: {fileID: 1209555947}
-  m_Layer: 9
-  m_Name: triggerArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 3936346786652291628, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1209555946
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1209555945}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.48, y: -1.13, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1836675160}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &1209555947
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1209555945}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 1.0406666, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 3.0813332, y: 1}
-  m_EdgeRadius: 0
 --- !u!1 &1228511782
 GameObject:
   m_ObjectHideFlags: 0
@@ -2911,7 +2162,7 @@ Transform:
   - {fileID: 1317736042}
   - {fileID: 1103020529}
   m_Father: {fileID: 0}
-  m_RootOrder: 20
+  m_RootOrder: 27
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1240074016
 GameObject:
@@ -2943,6 +2194,12 @@ Transform:
   m_Father: {fileID: 1815513305}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1279982442 stripped
+BoxCollider2D:
+  m_CorrespondingSourceObject: {fileID: 5226218537142015529, guid: c8d9285cf925a684b80689342d0ec44e,
+    type: 3}
+  m_PrefabInstance: {fileID: 5130375403708644222}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1286309334
 GameObject:
   m_ObjectHideFlags: 0
@@ -3179,43 +2436,13 @@ RectTransform:
   - {fileID: 1166710293}
   - {fileID: 1590088552}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &1337372721
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1337372722}
-  m_Layer: 9
-  m_Name: enemy_sprites
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1337372722
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1337372721}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 353002286}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1342763618
 GameObject:
   m_ObjectHideFlags: 0
@@ -3276,7 +2503,7 @@ Transform:
   - {fileID: 1286309335}
   - {fileID: 461454511}
   m_Father: {fileID: 0}
-  m_RootOrder: 22
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1368788337
 GameObject:
@@ -3446,11 +2673,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 23
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 59.72, y: -18.61}
+  m_AnchoredPosition: {x: 44.47, y: -7.77}
   m_SizeDelta: {x: 20, y: 5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1397524362
@@ -3660,7 +2887,7 @@ PrefabInstance:
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.2199974
+      value: -0.22000122
       objectReference: {fileID: 0}
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
@@ -3670,12 +2897,12 @@ PrefabInstance:
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -10
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
@@ -3685,7 +2912,7 @@ PrefabInstance:
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6474417508408526728, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
@@ -3750,12 +2977,42 @@ PrefabInstance:
     - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -49.7
+      value: -49.699997
       objectReference: {fileID: 0}
     - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: -18.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.000009700656
+      objectReference: {fileID: 0}
+    - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6474417508619831186, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 6474417508619831187, guid: 7d91cf7fc6c24f143ba973f7f2ddc0ab,
         type: 3}
@@ -4024,43 +3281,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -48.19, y: -21.15}
   m_SizeDelta: {x: 10.970602, y: 2.3229399}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1437318958
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1437318959}
-  m_Layer: 9
-  m_Name: enemy_sprites
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1437318959
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1437318958}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1836675160}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1517096335
 GameObject:
   m_ObjectHideFlags: 0
@@ -43747,40 +42974,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1518523186}
   m_CullTransparentMesh: 0
---- !u!1 &1584116719 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1131955118306753289, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-    type: 3}
-  m_PrefabInstance: {fileID: 57287804}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1584116720
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1584116719}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 929180e66b24a03409d059a292d34c64, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rayCast: {fileID: 1201065773}
-  raycastMask:
-    serializedVersion: 2
-    m_Bits: 1024
-  rayCastLength: 4
-  attackDistance: 2
-  moveSpeed: 2
-  timer: 2
-  leftLimit: {fileID: 1342763619}
-  rightLimit: {fileID: 1240074017}
---- !u!4 &1584116725 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-    type: 3}
-  m_PrefabInstance: {fileID: 57287804}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1589110757
 GameObject:
   m_ObjectHideFlags: 0
@@ -43888,7 +43081,7 @@ Transform:
   m_LocalScale: {x: 0.7, y: 0.7, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1589110761
 MonoBehaviour:
@@ -44214,11 +43407,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.93, y: -13.48}
+  m_AnchoredPosition: {x: -4.96, y: -13.48}
   m_SizeDelta: {x: 20, y: 5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1668684104
@@ -44415,7 +43608,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1701726209
 GameObject:
@@ -44585,7 +43778,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -44671,38 +43864,8 @@ Transform:
   m_LocalScale: {x: 1.1387004, y: 1.1200753, z: 1.1200753}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 26
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1735599593
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1735599594}
-  m_Layer: 9
-  m_Name: enemy_collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1735599594
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1735599593}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 353002286}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &1773367851
 GameObject:
   m_ObjectHideFlags: 0
@@ -44739,36 +43902,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1807453410
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1807453411}
-  m_Layer: 8
-  m_Name: raycast
-  m_TagString: Untagged
-  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1807453411
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1807453410}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.24, y: -1.48, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1836675160}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1815513304
 GameObject:
   m_ObjectHideFlags: 0
@@ -44779,7 +43912,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1815513305}
   m_Layer: 0
-  m_Name: bloon mov limt (1)
+  m_Name: bloon mov limt (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -44799,71 +43932,7 @@ Transform:
   - {fileID: 1342763619}
   - {fileID: 1240074017}
   m_Father: {fileID: 0}
-  m_RootOrder: 25
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1836675154 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1131955118306753289, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-    type: 3}
-  m_PrefabInstance: {fileID: 1187436123}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1836675157
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1836675154}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 929180e66b24a03409d059a292d34c64, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rayCast: {fileID: 1807453411}
-  raycastMask:
-    serializedVersion: 2
-    m_Bits: 1024
-  rayCastLength: 4
-  attackDistance: 2
-  moveSpeed: 2
-  timer: 2
-  leftLimit: {fileID: 1286309335}
-  rightLimit: {fileID: 461454511}
---- !u!4 &1836675160 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-    type: 3}
-  m_PrefabInstance: {fileID: 1187436123}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1836900953
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1836900954}
-  m_Layer: 8
-  m_Name: raycast
-  m_TagString: Untagged
-  m_Icon: {fileID: 419385456094870383, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1836900954
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1836900953}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.24, y: -1.48, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 353002286}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1919021708
 GameObject:
@@ -45031,13 +44100,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1919021708}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 35.2, y: -11.5, z: 0}
+  m_LocalPosition: {x: 35.2, y: -15.07, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 517733264}
   - {fileID: 242797171}
   m_Father: {fileID: 0}
-  m_RootOrder: 23
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1953758872
 PrefabInstance:
@@ -45059,7 +44128,7 @@ PrefabInstance:
     - target: {fileID: 3348315777731550578, guid: e1458b5b14dfee741b9772127682db2f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3348315777731550578, guid: e1458b5b14dfee741b9772127682db2f,
         type: 3}
@@ -45246,166 +44315,6 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
---- !u!1001 &2006729960
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1131955118306753282, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Constraints
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753282, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_GravityScale
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753289, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Name
-      value: blooncat (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 1.2314262
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 1.0221863
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Offset.x
-      value: -0.04367256
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Offset.y
-      value: -0.44265175
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_UsedByComposite
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.x
-      value: 0.56081307
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.pivot.y
-      value: 0.48291248
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.x
-      value: 1.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753292, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 1.7
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753294, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_FlipX
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753294, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: -7781385479087960072, guid: 9d6ffdca57dfeba48aa001f2f80dbe4d,
-        type: 3}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 26
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 33.14
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -6.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1131955118306753295, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1459926277965439960, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.46
-      objectReference: {fileID: 0}
-    - target: {fileID: 1459926277965439960, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.43
-      objectReference: {fileID: 0}
-    - target: {fileID: 3493642560162253768, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 7.63
-      objectReference: {fileID: 0}
-    - target: {fileID: 3493642560162253768, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.57
-      objectReference: {fileID: 0}
-    - target: {fileID: 8596611459759047561, guid: 4bed39a69e2d7d147b57c2c9b2106688,
-        type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: a54ae6ade155c86429c34ffb16bb3baa, type: 2}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4bed39a69e2d7d147b57c2c9b2106688, type: 3}
 --- !u!1001 &2065086604
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -45426,7 +44335,7 @@ PrefabInstance:
     - target: {fileID: 3348315777731550578, guid: e1458b5b14dfee741b9772127682db2f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 3348315777731550578, guid: e1458b5b14dfee741b9772127682db2f,
         type: 3}
@@ -45481,60 +44390,570 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: -6122313426562646314, guid: e1458b5b14dfee741b9772127682db2f, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: e1458b5b14dfee741b9772127682db2f, type: 3}
---- !u!1 &2081506814
-GameObject:
+--- !u!1001 &2105168833
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2081506815}
-  - component: {fileID: 2081506816}
-  m_Layer: 9
-  m_Name: hitBox
-  m_TagString: Untagged
-  m_Icon: {fileID: -1412012063857583412, guid: 0000000000000000d000000000000000, type: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2081506815
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2081506814}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.55, y: -0.46, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1584116725}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!61 &2081506816
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2081506814}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.22389793, y: 0.18420887}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.4215355, y: 0.31096458}
-  m_EdgeRadius: 0
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5130375401906703147, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: leftLimit
+      value: 
+      objectReference: {fileID: 1971615676}
+    - target: {fileID: 5130375401906703147, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: rightLimit
+      value: 
+      objectReference: {fileID: 713764171}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33.18308
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -6.857772
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015532, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_Name
+      value: blooncat (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_Collider
+      value: 
+      objectReference: {fileID: 115188309}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].x
+      value: 0.5699414
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].y
+      value: -1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].x
+      value: 0.5699414
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].x
+      value: -0.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].y
+      value: 0.049941402
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].x
+      value: -0.42994142
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].y
+      value: -1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].X
+      value: 5699707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].Y
+      value: -14500000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].X
+      value: 5699707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].Y
+      value: 500000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].X
+      value: -4300000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].Y
+      value: 499707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].X
+      value: -4299707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].Y
+      value: -14500000
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c8d9285cf925a684b80689342d0ec44e, type: 3}
+--- !u!1001 &2146749481
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5130375401906703147, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: leftLimit
+      value: 
+      objectReference: {fileID: 1342763619}
+    - target: {fileID: 5130375401906703147, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: rightLimit
+      value: 
+      objectReference: {fileID: 1240074017}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32.145443
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.685137
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015532, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_Name
+      value: blooncat (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_Collider
+      value: 
+      objectReference: {fileID: 938928827}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].x
+      value: 0.5699414
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].y
+      value: -1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].x
+      value: 0.5699414
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].x
+      value: -0.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].y
+      value: 0.049941402
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].x
+      value: -0.42994142
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].y
+      value: -1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].X
+      value: 5699707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].Y
+      value: -14500000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].X
+      value: 5699707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].Y
+      value: 500000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].X
+      value: -4300000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].Y
+      value: 499707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].X
+      value: -4299707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].Y
+      value: -14500000
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c8d9285cf925a684b80689342d0ec44e, type: 3}
+--- !u!1001 &5130375403708644222
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5130375401906703147, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: leftLimit
+      value: 
+      objectReference: {fileID: 1286309335}
+    - target: {fileID: 5130375401906703147, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: rightLimit
+      value: 
+      objectReference: {fileID: 461454511}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -44.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -17.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015530, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5226218537142015532, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_Name
+      value: blooncat
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_Collider
+      value: 
+      objectReference: {fileID: 1279982442}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].x
+      value: 0.5699414
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[0].y
+      value: -1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].x
+      value: 0.5699414
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[1].y
+      value: 0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].x
+      value: -0.43
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[2].y
+      value: 0.049941402
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].x
+      value: -0.42994142
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_CompositePaths.m_Paths.Array.data[0].Array.data[3].y
+      value: -1.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].X
+      value: 5699707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[0].Y
+      value: -14500000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].X
+      value: 5699707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[1].Y
+      value: 500000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].X
+      value: -4300000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[2].Y
+      value: 499707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].X
+      value: -4299707
+      objectReference: {fileID: 0}
+    - target: {fileID: 5259067016775476252, guid: c8d9285cf925a684b80689342d0ec44e,
+        type: 3}
+      propertyPath: m_ColliderPaths.Array.data[0].m_ColliderPaths.Array.data[0].Array.data[3].Y
+      value: -14500000
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c8d9285cf925a684b80689342d0ec44e, type: 3}

--- a/Assets/Scripts/Enemy_behaviour.cs
+++ b/Assets/Scripts/Enemy_behaviour.cs
@@ -19,6 +19,7 @@ public class Enemy_behaviour : MonoBehaviour
     public float timer; //Timer for cooldown between attacks
     public Transform leftLimit;
     public Transform rightLimit;
+    public int health = 2;
     #endregion
 
     #region Private Variables
@@ -32,15 +33,24 @@ public class Enemy_behaviour : MonoBehaviour
     private float intTimer;
     #endregion
 
+    Player player;
+    //Weapon weapon;
+
     void Awake()
     {
         SelectTarget();
         intTimer = timer; //Store the inital value of timer
         anim = GetComponent<Animator>();
+        player = FindObjectOfType<Player>();
     }
 
     void Update()
     {
+        if (health <= 0)
+        {
+            Destroy(gameObject);
+        }
+
         if (!attackMode)
         {
             Move();
@@ -75,12 +85,14 @@ public class Enemy_behaviour : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D trig)
     {
+
         if (trig.gameObject.tag == "Player")
         {
             target = trig.transform;
             inRange = true;
-            Flip(); 
+            Flip();
         }
+
     }
 
     void EnemyLogic()
@@ -91,15 +103,18 @@ public class Enemy_behaviour : MonoBehaviour
         {
             StopAttack();
         }
+        //else if (attackDistance >= distance && cooling == false && attackMode == true)
         else if (attackDistance >= distance && cooling == false)
         {
             Attack();
+            cooling = true;
         }
 
         if (cooling)
         {
+            //anim.SetBool("Attack", false);
             Cooldown();
-            anim.SetBool("Attack", false);
+            //anim.SetBool("Attack", false);
         }
     }
 
@@ -122,6 +137,14 @@ public class Enemy_behaviour : MonoBehaviour
 
         anim.SetBool("canWalk", false);
         anim.SetBool("Attack", true);
+
+        if (anim.GetCurrentAnimatorStateInfo(0).IsName("Enemy_attack") == true)
+        {
+            Debug.Log("Enemy attacked");
+            player.OnHit();
+        }
+
+        //player.OnHit();
     }
 
     void Cooldown()
@@ -129,14 +152,19 @@ public class Enemy_behaviour : MonoBehaviour
         timer -= Time.deltaTime;
 
         if (timer <= 0 && cooling && attackMode)
+        //if (timer <= 0 && cooling)
         {
             cooling = false;
             timer = intTimer;
+
+            //attackMode = true;
+            //anim.SetBool("Attack", true);
         }
     }
 
     void StopAttack()
     {
+        //cooling = true;
         cooling = false;
         attackMode = false;
         anim.SetBool("Attack", false);
@@ -187,13 +215,14 @@ public class Enemy_behaviour : MonoBehaviour
     void Flip()
     {
         Vector3 rotation = transform.eulerAngles;
-        if (transform.position.x > target.position.x) 
+
+        if (transform.position.x > target.position.x)
         {
             rotation.y = 180;
+            Debug.Log("Twist");
         }
         else
         {
-            Debug.Log("Twist");
             rotation.y = 0;
         }
 
@@ -201,5 +230,10 @@ public class Enemy_behaviour : MonoBehaviour
         //rotation.y = (currentTarget.position.x < transform.position.x) ? rotation.y = 180f : rotation.y = 0f;
 
         transform.eulerAngles = rotation;
+    }
+
+    public void OnHit()
+    {
+        health--;
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -107,11 +107,17 @@ public class Player : MonoBehaviour {
     void Move() {
         xVelocity = Input.GetAxisRaw("Horizontal");
         animator.SetBool("IsMove", xVelocity != 0);
-        transform.Translate(xVelocity * speed, 0, 0);
+
+        //transform.Translate(xVelocity * speed, 0, 0);
+        transform.Translate(-xVelocity * speed, 0, 0);
+        
         //flipping
         if (xVelocity != 0) {
-            transform.localScale = new Vector3(-xVelocity, 1, 1);
-            if(!runAudio.isPlaying&&isOnGround)
+
+            //transform.localScale = new Vector3(-xVelocity, 1, 1);
+            transform.localScale = new Vector3(xVelocity, 1, 1);
+            
+            if (!runAudio.isPlaying && isOnGround)
                 runAudio.Play();
         }
         else


### PR DESCRIPTION
Player takes damage from balloon cat now 
Attack animation of bloon cat was too fast at 1.0 speed with relation with when the player took damage, so I slowed it down to 0.75 speed
Player now faces the correct direction when game starts (code modified to account for this change)
Adjusted the trigger collider for bloon cat to help fix part of the Flip() issues (there are still some other bugs though)
Made a prefab for bloon cat
Moved some of the text around